### PR TITLE
Component route test

### DIFF
--- a/server/app/routes/components/index.js
+++ b/server/app/routes/components/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var router = require('express').Router();
-//var Component = require('../db/models/component');
 const Component = require('mongoose').model('Component');
 module.exports = router;
 
@@ -13,13 +12,16 @@ router.param('componentId', function(req, res, next, componentId){
   .catch(next);
 });
 
-router.get('/', function (req, res, next) {
-	Component.find()
-	.then(function(components){
-		res.json(components);
-	})
-	.catch(next);
-    
+router.get('/:componentId?', function (req, res, next) {
+	if (req.params.componentId) {
+		res.json(req.component);
+	} else {
+		Component.find()
+			.then(function(foundComponents){
+				res.json(foundComponents);
+			})
+			.catch(next);
+	}
 });
 
 router.put('/:componentId', function (req, res, next) {
@@ -35,7 +37,7 @@ router.put('/:componentId', function (req, res, next) {
 router.post('/', function (req, res, next) {
 	Component.create(req.body)
 	.then(function(createdComponent){
-		res.json(createdComponent);
+		res.status(201).json(createdComponent);
 	})
 	.catch(next);
     
@@ -44,7 +46,7 @@ router.post('/', function (req, res, next) {
 router.delete('/:componentId', function (req, res, next) {
   req.component.remove()
   .then(function(){
-      res.status(204).end();
+      res.sendStatus(204);
   })
   .catch(next);
     

--- a/server/app/routes/index.js
+++ b/server/app/routes/index.js
@@ -3,10 +3,10 @@ var router = require('express').Router();
 module.exports = router;
 
 router.use('/members', require('./members'));
-router.use('/api/components', require('./components'));
-router.use('/api/screenplays', require('./screenplays'));
-router.use('/api/users', require('./user'));
-router.use('/api/character', require('./character'));
+router.use('/components', require('./components'));
+router.use('/screenplays', require('./screenplays'));
+router.use('/users', require('./user'));
+router.use('/character', require('./character'));
 
 // Make sure this is after all of
 // the registered routes!

--- a/server/db/models/component.js
+++ b/server/db/models/component.js
@@ -15,7 +15,7 @@ var schema = new mongoose.Schema({
         type: String,
         required: true
     }
-});
+}, {toObject: {virtuals: true}, toJSON: {virtuals: true}});
 
 schema.virtual('intExt').get(function () {
   if(this.type === 'location'){

--- a/server/db/models/scene.js
+++ b/server/db/models/scene.js
@@ -3,7 +3,7 @@ var mongoose = require('mongoose');
 var _ = require('lodash');
 
 var schema = new mongoose.Schema({
-    header: {type: String, required: true}
+    header: {type: String, required: true},
     components: [
         {type: mongoose.Schema.Types.ObjectId, ref: 'Component', index: true}
     ],
@@ -16,20 +16,21 @@ var schema = new mongoose.Schema({
     }
 });
 
-schema.pre('save', function(next) {
+schema.pre('validate', function(next) {
     var Component = mongoose.model('Component');
     
     if (this.components.length === 0) {next(); }
     var compstoPop = this.components.filter((ele) => !ele.type);
     var comps = this.components.filter((ele) => ele.type);
     if (comps.length > 0) {
-        this.header = this.header = comps.find(ele => ele.type === 'location');
+        this.header = comps.find(ele => ele.type === 'location').text;
+        next();
     }
     if (compstoPop.length === 0){next(); }
     Component.find({'_id': { $in: compstoPop}})
     .then(foundComps => {
         if (!foundComps) {next(); }
-        this.header = foundComps.find(ele => ele.type === 'location');
+        this.header = foundComps.find(ele => ele.type === 'location').text;
         next();
     });
 });

--- a/tests/server/models/component-test.js
+++ b/tests/server/models/component-test.js
@@ -44,12 +44,13 @@ describe('Component model', function () {
     });
 
     describe('Virtuals', function () {
+
         it('interiour/exteriour virtual', function () {
             return Component.create({type: 'location', text: 'INT. The Coconut Grove Nightclub - night'})
             .then(function(created){
-                expect(created.intExt).to.equal('INT.'); 
-                expect(created.location).to.equal('The Coconut Grove Nightclub - night'); });
+                expect(created.intExt).to.equal('INT.'); });
         });
+
         it('location virtual', function () {
             return Component.create({type: 'location', text: 'INT. The Coconut Grove Nightclub - night'})
             .then(function(created){

--- a/tests/server/models/scene-test.js
+++ b/tests/server/models/scene-test.js
@@ -68,9 +68,8 @@ describe('Scene model', function () {
 
         it('Pre-Save Hook to Populate Heading', function () {
             return Scene.findOne()
-            .populate('header')
             .then(function(foundScene){
-                expect(foundScene.header.type).to.equal('location') ;
+                expect(foundScene.header).to.be.a('string') ;
             });
         });
     });

--- a/tests/server/routes/component.js
+++ b/tests/server/routes/component.js
@@ -1,0 +1,93 @@
+
+var mongoose = require('mongoose');
+var models = require('../models/create-dummy-entries');
+
+var expect = require('chai').expect;
+
+var dbURI = 'mongodb://localhost:27017/testingDB';
+var clearDB = require('mocha-mongoose')(dbURI);
+
+var supertest = require('supertest');
+var app = require('../../../server/app');
+
+describe('Component Route', function () {
+	var comp1;
+	var comp2;
+	var guestAgent;
+
+	beforeEach('Establish DB connection', function (done) {
+		if (mongoose.connection.db) return done();
+		mongoose.connect(dbURI, done);
+	});
+
+	afterEach('Clear test database', function (done) {
+		clearDB(done);
+	});
+
+	describe('RESTful Functionality', function () {
+
+		beforeEach('Create guest agent', function () {
+			guestAgent = supertest.agent(app);
+		});
+
+		beforeEach('Seed DB', function () {
+			return models.createComponents()
+			.then((ele, ele2) => {
+				comp1 = ele;
+				comp2 = ele2; 
+			});
+		});
+
+		it('should return all components', function (done) {
+			guestAgent.get('/api/components/')
+			.expect(200)
+			.end(function(err, res){
+				if (err) return done(err);
+				expect(res.status).to.equal(200);
+				expect(res.body).to.have.length(2);
+				done();
+			});
+		});
+
+		it('should return correct component', function (done) {
+			guestAgent.get('/api/components/'+comp1._id)
+			.expect(200)
+			.end(function(err, res){
+				if (err) return done(err);
+				expect(res.status).to.equal(200);
+				done();
+			});
+		});
+
+		it('should post & return new components with virtuals populated', function (done) {
+			guestAgent.post('/api/components/').send({type: 'location', text: 'INT. the mountain top'})
+			.expect(201)
+			.end(function(err, res){
+				if (err) return done(err);
+				expect(res.body.text).to.equal('INT. the mountain top');
+				expect(res.body).to.have.property('_id');
+				expect(res.body).to.have.property('location');
+				expect(res.body).to.have.property('intExt');
+				done();
+			});
+		});
+ 
+		it('should delete component', function (done) {
+			guestAgent.delete('/api/components/'+comp1._id)
+			.expect(204)
+			.end(function(err, res){
+				if (err) return done(err);
+				guestAgent.get('/api/components/')
+				.expect(200)
+				.end(function(err, res){
+					if (err) return done(err);
+					expect(res.body).to.have.length(1);
+					done();
+				});
+			});
+		});
+	});
+
+});
+
+


### PR DESCRIPTION
1. Created file /test/models/create-dummy-entries.
   - This file can be used to populate test dbs with objects.  This was done in an already merged pull requests, but mentioning here in case it's useful.  
   
   ```
   var models = require('../models/create-dummy-entries');
   beforeEach('Seed DB', function () {
   return models.createComponents()
   .then((ele, ele2) => {
       comp1 = ele;
       comp2 = ele2; 
   });
   });
   ```
2. Created Component Model Test
3. Updated Scene Model
   - Changed pre-save hook to a pre-validate hook.  
   - Changed header from component reference field to string field.  String equals text of first component with type of "location." 
4. Updated Component Model
   - Set schema to export virtuals by default.
5. Updated Component Router
   - Modified get route so that it will return all components if ID is not passed as a parameter.  
